### PR TITLE
Changeable unfocused FPS

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -21,6 +21,7 @@ namespace FrameFocus
         public static bool isDebug;
         public static MelonPreferences_Category melon;
         public static MelonPreferences_Entry<int> FrameLimit;
+        public static MelonPreferences_Entry<int> FrameLimitUnfocused;
         public static MelonPreferences_Entry<bool> allowFrameLimit;
         public static MelonPreferences_Entry<bool> allowVRUse;
         public static MelonPreferences_Entry<bool> override_emmVRC;
@@ -36,6 +37,7 @@ namespace FrameFocus
             melon = MelonPreferences.CreateCategory(BuildInfo.Name, BuildInfo.Name);
             allowFrameLimit = (MelonPreferences_Entry<bool>)melon.CreateEntry("allowFrameLimit", false, "Toggle Frame Focus");
             FrameLimit = (MelonPreferences_Entry<int>)melon.CreateEntry("FrameLimit", 90, "Max Frame Limit");
+            FrameLimitUnfocused = (MelonPreferences_Entry<int>)melon.CreateEntry("FrameLimitUnfocused", 5, "Unfocused Frame Limit");
             allowVRUse = (MelonPreferences_Entry<bool>)melon.CreateEntry("allowVRUse", false, "Allow VR to Limit FrameRate");
             override_emmVRC = (MelonPreferences_Entry<bool>)melon.CreateEntry("override_emmVRC", false, "Make FrameFocus ignore emmVRC integration (only works if emmVRC is detected)");
 
@@ -61,6 +63,7 @@ namespace FrameFocus
                 MelonLogger.Msg("[Debug] \n" +
                     " ================= Preferences Values: ============== \n" +
                     " ============== int  FrameLimit      = " + FrameLimit.Value.ToString() + "\n" +
+                    " ============== int FrameLimitUnfocused = " + FrameLimitUnfocused.Value.ToString() + "\n" +
                     " ============== bool allowFrameLimit = " + allowFrameLimit.Value.ToString() + "\n" +
                     " ============== bool allowVRUse      = " + allowVRUse.Value.ToString() + "\n" +
                     " ============== bool override_emmVRC = " + override_emmVRC.Value.ToString() + "\n" +

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Game: VRChat (2021.1.2(p1) [build 1046 - 1048])<br>
 [FrameFocus]
 allowFrameLimit = false
 FrameLimit = 90
+FrameLimitUnfocused = 5
 allowVRUse = false
 override_emmVRC = false
 ```
 <br>
 allowFrameLimit - (Main Toggle) Toggle the framerate when the application is focused or not<br>
 FrameLimit - sets game's Frame Rate<br>
+FrameLimitUnfocused - sets game's Frame Rate when unfocused<br>
 allowVRUse - Allows the function to be used with VR Mode<br>
 override_emmVRC - Make FrameFocus ignore emmVRC integration (only works if emmVRC is detected)
 

--- a/Utilities/StartLate.cs
+++ b/Utilities/StartLate.cs
@@ -38,7 +38,7 @@ namespace FrameFocus.Utilities
                             Application.targetFrameRate = (int)FrameFocus.FrameLimit.Value; // Sets game's FrameRate to Given Target FPS
                     }
                     else
-                        Application.targetFrameRate = (int)FrameFocus.FrameLimitUnfocused.Value; // Sets game's FrameRate to 5 FPS
+                        Application.targetFrameRate = (int)FrameFocus.FrameLimitUnfocused.Value; // Sets game's FrameRate to target FPS
                 }
             }
         }

--- a/Utilities/StartLate.cs
+++ b/Utilities/StartLate.cs
@@ -38,7 +38,7 @@ namespace FrameFocus.Utilities
                             Application.targetFrameRate = (int)FrameFocus.FrameLimit.Value; // Sets game's FrameRate to Given Target FPS
                     }
                     else
-                        Application.targetFrameRate = (int)5; // Sets game's FrameRate to 5 FPS
+                        Application.targetFrameRate = (int)FrameFocus.FrameLimitUnfocused.Value; // Sets game's FrameRate to 5 FPS
                 }
             }
         }


### PR DESCRIPTION
5 FPS is a bit too low for me, since I like alt-tabbing to another monitor whilst still paying some attention to VRChat. This change would make the unfocused FPS configurable instead of statically being 5.